### PR TITLE
2.0.0: NET 6 & MooVC 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 The MooVC Infrastructural Serialization library for NewtonSoft JSON is designed to encapsulate the Newtonsoft.Json implementation through the standardized MooVC.Serialization interpretation, facilitating ease of consumption within inner layers without direct coupling to infrastructural concerns.
 
-# Release v1.0.0
+# Release v2.0.0
 
-- Initial Release
+- Changed to target MooVC V6.* (**breaking change**).
+- Changed to target NET 6 in addition to NET 5 and NET Standard 2.1.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,14 @@ steps:
     useConfigFile: true
     configFilePath: './gitversion.yml'
 
+- task: UseDotNet@2
+  condition: succeeded()
+  displayName: 'Use .NET 6 Core SDK'
+  inputs:
+    packageType: 'sdk'
+    version: '6.x'
+    includePreviewVersions: true
+
 - task: DotNetCoreCLI@2
   condition: succeeded()
   displayName: 'Restore Nuget Packages for Solution'

--- a/src/MooVC.Infrastructure.Serialization.Json.Newtonsoft.Tests/MooVC.Infrastructure.Serialization.Json.Newtonsoft.Tests.csproj
+++ b/src/MooVC.Infrastructure.Serialization.Json.Newtonsoft.Tests/MooVC.Infrastructure.Serialization.Json.Newtonsoft.Tests.csproj
@@ -16,14 +16,14 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/MooVC/moovc.infrastructure.serialization.json.newtonsoft.git</RepositoryUrl>
     <RootNamespace>MooVC.Infrastructure.Serialization.Json.Newtonsoft</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="3.*">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
     <PackageReference Include="Moq" Version="4.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.*">

--- a/src/MooVC.Infrastructure.Serialization.Json.Newtonsoft/MooVC.Infrastructure.Serialization.Json.Newtonsoft.csproj
+++ b/src/MooVC.Infrastructure.Serialization.Json.Newtonsoft/MooVC.Infrastructure.Serialization.Json.Newtonsoft.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
-    <PackageReference Include="MooVC" Version="6.0.0-beta*" />
+    <PackageReference Include="MooVC" Version="6.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta*">
       <PrivateAssets>all</PrivateAssets>

--- a/src/MooVC.Infrastructure.Serialization.Json.Newtonsoft/MooVC.Infrastructure.Serialization.Json.Newtonsoft.csproj
+++ b/src/MooVC.Infrastructure.Serialization.Json.Newtonsoft/MooVC.Infrastructure.Serialization.Json.Newtonsoft.csproj
@@ -16,12 +16,12 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/MooVC/moovc.infrastructure.serialization.json.newtonsoft.git</RepositoryUrl>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>netstandard2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.*" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.*" PrivateAssets="All" />
-    <PackageReference Include="MooVC" Version="5.*" />
+    <PackageReference Include="MooVC" Version="6.0.0-beta*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.*" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta*">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Changed to target MooVC V6.* (**breaking change**).
- Changed to target NET 6 in addition to NET 5 and NET Standard 2.1.